### PR TITLE
Update .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,8 @@
 version: 2
-
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
To fix doc builds on RTD, the config must be changed. See [Deprecation notice and migration advice](https://blog.readthedocs.com/use-build-os-config/)