### PR TITLE
fix `delayMicroseconds()` implementation

### DIFF
--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -2,13 +2,14 @@ name: Arduino
 
 on:
   pull_request:
-    types: [opened, reopened]
+    branches: [master]
     paths:
       - ".github/workflows/build_arduino.yml"
       - "examples/**/*.ino"
       - "src/*.h"
       - "src/*.cpp"
   push:
+    branches: [master]
     paths:
       - ".github/workflows/build_arduino.yml"
       - "examples/**/*.ino"

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   pull_request:
-    types: [opened, reopened]
+    branches: [master]
     paths:
       - "src/CirquePinnacle.h"
       - "docs/**"
@@ -10,6 +10,7 @@ on:
       - "examples/**/*.cpp"
       - ".github/workflows/build_docs.yml"
   push:
+    branches: [master]
     paths:
       - "src/CirquePinnacle.h"
       - "docs/**"
@@ -18,7 +19,6 @@ on:
       - ".github/workflows/build_docs.yml"
   release:
     types: [published, edited]
-    branches: [master]
   workflow_dispatch:
 
 jobs:

--- a/src/utility/linux_kernel/time_keeping.cpp
+++ b/src/utility/linux_kernel/time_keeping.cpp
@@ -19,7 +19,6 @@
 #ifndef ARDUINO
     #include <time.h>
     #include <chrono>
-    #include <sys/time.h>
     #include "time_keeping.h"
 
     #ifdef __cplusplus
@@ -41,7 +40,7 @@ namespace cirque_pinnacle_arduino_wrappers {
     {
         struct timespec req;
         req.tv_sec = (time_t)microseconds / 1000000;
-        req.tv_nsec = (microseconds / 1000000) * 1000;
+        req.tv_nsec = (microseconds % 1000000) * 1000;
         //nanosleep(&req, (struct timespec *)NULL);
         clock_nanosleep(CLOCK_REALTIME, 0, &req, NULL);
     }

--- a/src/utility/mraa/time_keeping.cpp
+++ b/src/utility/mraa/time_keeping.cpp
@@ -19,7 +19,6 @@
 #ifndef ARDUINO
     #include <time.h>
     #include <chrono>
-    #include <sys/time.h>
     #include "time_keeping.h"
 
     #ifdef __cplusplus
@@ -41,7 +40,7 @@ namespace cirque_pinnacle_arduino_wrappers {
     {
         struct timespec req;
         req.tv_sec = (time_t)microseconds / 1000000;
-        req.tv_nsec = (microseconds / 1000000) * 1000;
+        req.tv_nsec = (microseconds % 1000000) * 1000;
         //nanosleep(&req, (struct timespec *)NULL);
         clock_nanosleep(CLOCK_REALTIME, 0, &req, NULL);
     }

--- a/src/utility/pigpio/time_keeping.cpp
+++ b/src/utility/pigpio/time_keeping.cpp
@@ -40,7 +40,7 @@ namespace cirque_pinnacle_arduino_wrappers {
     {
         struct timespec req;
         req.tv_sec = (time_t)microseconds / 1000000;
-        req.tv_nsec = (microseconds / 1000000) * 1000;
+        req.tv_nsec = (microseconds % 1000000) * 1000;
         //nanosleep(&req, (struct timespec *)NULL);
         clock_nanosleep(CLOCK_REALTIME, 0, &req, NULL);
     }


### PR DESCRIPTION
This affects `linux_kernel`, `mraa`, and `pigpio` drivers (on linux).

It was a simple math operator mistake that resulted in no delay if the specified microseconds was less than 1000000.