### PR TITLE
update to clang-format v14; update pre-commit hooks

### DIFF
--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   check_formatting:
-    uses: 2bndy5/CirquePinnacle/.github/workflows/cpp_lint.yaml@master
+    uses: ./.github/workflows/cpp_lint.yaml
     with:
       extensions: 'ino'
 
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Compile examples
         uses: arduino/compile-sketches@main
@@ -66,12 +66,18 @@ jobs:
             - examples/anymeas_mode
             - examples/relative_mode
 
+      - name: sketch reports
+        if: matrix.enable-deltas-report
+        id: delta-report-name
+        run: >-
+          echo "report-name=${{ matrix.fqbn }}" | tr : - >> "$GITHUB_OUTPUT"
+
       # This step is needed to pass the size data to the report job
       - name: Upload sketches report to workflow artifact
         if: matrix.enable-deltas-report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.SKETCH_REPORTS_PATH }}
+          name: arduino-deltas-${{ steps.delta-report-name.outputs.report-name }}
           path: ${{ env.SKETCH_REPORTS_PATH }}
 
   report_size_deltas:
@@ -79,11 +85,12 @@ jobs:
     needs: [build]
     steps:
       - name: Download sketches reports artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: ${{ env.SKETCH_REPORTS_PATH }}
+          pattern: arduino-deltas-*
           path: ${{ env.SKETCH_REPORTS_PATH }}
 
-      - uses: arduino/report-size-deltas@v1
+      - uses: 2bndy5/report-size-deltas@update-comment
         with:
           sketches-reports-source: ${{ env.SKETCH_REPORTS_PATH }}
+          update-comment: true

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,11 +25,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install sphinx deps
         run: python -m pip install -r docs/requirements.txt
@@ -39,7 +39,7 @@ jobs:
         run: sphinx-build . _build/html
 
       - name: Save sphinx docs as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Cirque_Pinnacle_docs
           path: ${{ github.workspace }}/docs/_build/html

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,9 +1,8 @@
 name: Linux
 
 on:
-  pull_request_target:
   pull_request:
-    types: [opened, reopened]
+    branches: [master]
     paths:
       - "library.properties" # CMake gets lib info from here
       - "src/*.h"
@@ -19,6 +18,7 @@ on:
       - "examples/linux/*"
       - ".github/workflows/build_linux.yml"
   push:
+    branches: [master]
     paths:
       - "library.properties" # CMake gets lib info from here
       - "src/*.h"
@@ -43,9 +43,9 @@ env:
 
 jobs:
   check_formatting:
-    uses: 2bndy5/CirquePinnacle/.github/workflows/cpp_lint.yaml@master
+    uses: ./.github/workflows/cpp_lint.yaml
     with:
-      ignore: 'examples|examples_pico|utility/bcm2xxx/bcm2835.h|utility/bcm2xxx/bcm2835.c'
+      ignore: 'examples|!examples/linux|src/utility/bcm2xxx/bcm2835.h|src/utility/bcm2xxx/bcm2835.c'
   build:
     needs: check_formatting
     runs-on: ubuntu-latest
@@ -88,13 +88,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
 
-      - name: get repo info
-        id: lib-info
-        run: echo "name=$(echo ${{ github.repository }} | sed 's;.\+/;;')" >> $GITHUB_OUTPUT
-
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          path: ${{ steps.lib-info.outputs.name }}
+          path: ${{ github.event.repository.name }}
 
       - name: provide mraa
         if: matrix.driver == 'mraa'
@@ -105,7 +101,7 @@ jobs:
           cd build
           cmake .. -D BUILDSWIGNODE=OFF \
           -D CMAKE_INSTALL_PREFIX=/usr/${{ matrix.toolchain.usr_dir }} \
-          -D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/src/cmake/toolchains/${{ matrix.toolchain.compiler }}.cmake
+          -D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/${{ github.event.repository.name }}/src/cmake/toolchains/${{ matrix.toolchain.compiler }}.cmake
           sudo make install
 
       - name: provide pigpio
@@ -119,58 +115,58 @@ jobs:
           mkdir build
           cd build
           cmake .. -D CMAKE_INSTALL_PREFIX=/usr/${{ matrix.toolchain.usr_dir }} \
-          -D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/src/cmake/toolchains/${{ matrix.toolchain.compiler }}.cmake
+          -D CMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/${{ github.event.repository.name }}/src/cmake/toolchains/${{ matrix.toolchain.compiler }}.cmake
           make
           sudo make install
 
       - name: create CMake build environment
-        run: cmake -E make_directory ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build
+        run: cmake -E make_directory ${{ github.workspace }}/${{ github.event.repository.name }}/build
 
       - name: configure lib
-        working-directory: ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build
+        working-directory: ${{ github.workspace }}/${{ github.event.repository.name }}/build
         run: |
           cmake ../src -D CMAKE_BUILD_TYPE=$BUILD_TYPE \
           -D CMAKE_INSTALL_PREFIX=/usr/${{ matrix.toolchain.usr_dir }} \
           -D CMAKE_TOOLCHAIN_FILE=cmake/toolchains/${{ matrix.toolchain.compiler }}.cmake
 
       - name: build lib
-        working-directory: ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build
+        working-directory: ${{ github.workspace }}/${{ github.event.repository.name }}/build
         run: cmake --build .
 
       - name: install lib
-        working-directory: ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build
+        working-directory: ${{ github.workspace }}/${{ github.event.repository.name }}/build
         run: sudo cmake --install .
 
       - name: package lib
         if: endsWith(matrix.i2c-bus, 'OFF') && endsWith(matrix.dr-pin, 'OFF')
-        working-directory: ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build
+        working-directory: ${{ github.workspace }}/${{ github.event.repository.name }}/build
         run: sudo cpack
 
       - name: Save artifact
-        if: endsWith(matrix.i2c-bus, 'OFF') && endsWith(matrix.dr-pin, 'OFF')
-        uses: actions/upload-artifact@v3
+        if: endsWith(matrix.i2c-bus, 'OFF') && endsWith(matrix.dr-pin, 'OFF') && startsWith(matrix.toolchain.compiler, 'arm')
+        uses: actions/upload-artifact@v4
         with:
-          name: pkg_${{ steps.lib-info.outputs.name }}
+          name: pkg_${{ github.event.repository.name }}_${{ matrix.driver }}_${{ matrix.toolchain.compiler }}
           path: |
-            ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build/pkgs/*.deb
-            ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build/pkgs/*.rpm
+            ${{ github.workspace }}/${{ github.event.repository.name }}/build/pkgs/*.deb
+            ${{ github.workspace }}/${{ github.event.repository.name }}/build/pkgs/*.rpm
 
       - name: Upload Release assets
         if: github.event_name == 'release' && (matrix.toolchain.compiler == 'armhf' || matrix.toolchain.compiler == 'arm64') && (matrix.driver =='bcm2xxx' || matrix.driver =='linux_kernel') && (endsWith(matrix.i2c-bus, 'OFF') && endsWith(matrix.dr-pin, 'OFF'))
         uses: shogo82148/actions-upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build/pkgs/lib*"
+          asset_path: "${{ github.workspace }}/${{ github.event.repository.name }}/build/pkgs/lib*"
 
       - name: clean build environment
-        working-directory: ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build
+        working-directory: ${{ github.workspace }}/${{ github.event.repository.name }}/build
         run: sudo rm -r ./*
 
       - name: provide ncurses
         # This script assumes that any examples using ncurses reside in a 'ncurses' subdirectory
         # as is the case w/ RF24Mesh, RF24Gateway, and any new ncurses examples going forward.
         run: |
-          if [[ -d ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/examples/linux/ncurses ]]; then
+          if [[ -d ${{ github.workspace }}/${{ github.event.repository.name }}/examples/linux/ncurses ]]; then
             if [[ ${{ matrix.toolchain.compiler }} == 'default' ]]; then
               sudo apt-get install libncurses5-dev
             else
@@ -190,12 +186,12 @@ jobs:
           fi
 
       - name: configure examples
-        working-directory: ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build
+        working-directory: ${{ github.workspace }}/${{ github.event.repository.name }}/build
         run: |
           cmake ../examples/linux \
           -D CMAKE_TOOLCHAIN_FILE=../src/cmake/toolchains/${{ matrix.toolchain.compiler }}.cmake \
           ${{ matrix.i2c-bus }} ${{ matrix.dr-pin }}
 
       - name: build examples
-        working-directory: ${{ github.workspace }}/${{ steps.lib-info.outputs.name }}/build
+        working-directory: ${{ github.workspace }}/${{ github.event.repository.name }}/build
         run: cmake --build .

--- a/.github/workflows/build_pico_sdk.yml
+++ b/.github/workflows/build_pico_sdk.yml
@@ -2,7 +2,7 @@ name: Pico SDK
 
 on:
   pull_request:
-    types: [opened, reopened]
+    branches: [master]
     paths:
       - "src/*.cpp"
       - "!src/py_bindings.cpp"
@@ -12,6 +12,7 @@ on:
       - "examples/pico_sdk/**"
       - ".github/workflows/build_pico_sdk.yml"
   push:
+    branches: [master]
     paths:
       - "src/*.cpp"
       - "!src/py_bindings.cpp"
@@ -23,9 +24,9 @@ on:
 
 jobs:
   check_formatting:
-    uses: 2bndy5/CirquePinnacle/.github/workflows/cpp_lint.yaml@master
+    uses: ./.github/workflows/cpp_lint.yaml
     with:
-      ignore: 'examples/pico_sdk|'
+      ignore: '!examples/pico_sdk|'
   build:
     needs: check_formatting
     runs-on: ubuntu-latest
@@ -52,7 +53,7 @@ jobs:
         id: lib-info
         run: echo "name=$(echo ${{ github.repository }} | sed 's;.\+/;;')" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: ${{ steps.lib-info.outputs.name }}
 
@@ -60,7 +61,7 @@ jobs:
         run: sudo apt update && sudo apt install gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 
       - name: Clone pico-sdk
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: raspberrypi/pico-sdk
           # master branch is latest stable release
@@ -88,7 +89,7 @@ jobs:
         run: cmake --build . --config $BUILD_TYPE
 
       - name: Save artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: examples_pico_${{ matrix.board }}_${{ matrix.i2c-bus }}_${{ matrix.dr-pin }}
           path: |

--- a/.github/workflows/build_platformio.yml
+++ b/.github/workflows/build_platformio.yml
@@ -2,12 +2,13 @@ name: PlatformIO
 
 on:
   pull_request:
-    types: [opened, reopened]
+    branches: [master]
     paths:
       - ".github/workflows/build_platformio.yml"
       - "library.json"
       - "examples/**/*.ino"
   push:
+    branches: [master]
     paths:
       - ".github/workflows/build_platformio.yml"
       - "library.json"
@@ -20,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: get lib info
         id: lib-info
@@ -29,7 +30,7 @@ jobs:
           echo "release=$(awk -F "=" '/version/ {print $2}' library.properties)" >> $GITHUB_OUTPUT
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
@@ -42,7 +43,7 @@ jobs:
         run: pio package pack -o PlatformIO-${{ steps.lib-info.outputs.name }}-${{ steps.lib-info.outputs.release }}.tar.gz
 
       - name: Save artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: PIO_pkg_${{ steps.lib-info.outputs.name }}
           path: PlatformIO*.tar.gz
@@ -62,7 +63,7 @@ jobs:
         run: pio package publish --owner 2bndy5 --non-interactive
 
   check_formatting:
-    uses: 2bndy5/CirquePinnacle/.github/workflows/cpp_lint.yaml@master
+    uses: ./.github/workflows/cpp_lint.yaml
     with:
       extensions: ino
 
@@ -90,7 +91,7 @@ jobs:
 
     steps:
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -98,17 +99,17 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Cache PlatformIO
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.platformio
           key: ${{ runner.os }}-${{ matrix.board }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install PlatformIO
         run: |

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -1,12 +1,11 @@
 name: Python
 
 on:
-  pull_request_target:
   workflow_dispatch:
   release:
     types: [published]
   pull_request:
-    types: [opened, reopened]
+    branches: [master]
     paths:
       - "src/*.h"
       - "src/*.cpp"
@@ -17,6 +16,7 @@ on:
       - "src/utility/linux_kernel/*"
       - ".github/workflows/build_python.yml"
   push:
+    branches: [master]
     paths:
       - "src/*.h"
       - "src/*.cpp"
@@ -33,12 +33,12 @@ jobs:
     steps:
       - name: Set up Python
         id: python-setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
       - name: Checkout Current Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -50,7 +50,7 @@ jobs:
         run: python -m build -s
 
       - name: Cache pre-commit venv
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
           path: '~/.cache/pre-commit'
@@ -63,7 +63,7 @@ jobs:
         run: twine check dist/*
 
       - name: Save distributable source as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "cirque_pinnacle-sdist"
           path: ${{ github.workspace }}/dist
@@ -75,7 +75,7 @@ jobs:
       BUILD_ARCH: native
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
@@ -86,7 +86,7 @@ jobs:
           python3 -m pip install twine
 
       - name: Fetch distributable source artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "cirque_pinnacle-sdist"
           path: ${{ github.workspace }}/sdist
@@ -95,7 +95,7 @@ jobs:
         run: pip install sdist/*.tar.gz -v
 
       - name: Checkout Current Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
@@ -125,7 +125,7 @@ jobs:
         run: python3 -m twine check dist/*
 
       - name: Save distributable wheels as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "cirque_pinnacle-bdist"
           path: ${{ github.workspace }}/dist
@@ -136,18 +136,18 @@ jobs:
     needs: [check_source, build_linux]
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 
       - name: Fetch distributable wheel artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "cirque_pinnacle-bdist"
           path: ${{ github.workspace }}/dist
 
       - name: Fetch distributable source artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: "cirque_pinnacle-sdist"
           path: ${{ github.workspace }}/dist

--- a/.github/workflows/cpp_lint.yaml
+++ b/.github/workflows/cpp_lint.yaml
@@ -16,24 +16,24 @@ jobs:
   cpp_linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      # Ubuntu 22.04 runners no longer ship with clang-format-12
       - name: Install linter python package and clang-format
         run: |
-          sudo apt-get install clang-format-12
+          sudo apt-get install clang-format-14
           python3 -m pip install cpp-linter
       - name: run linter as a python package
         id: linter
-        run: |
-          cpp-linter \
-          --version=12 \
-          --style=file \
-          --tidy-checks='-*' \
-          --files-changed-only='False' \
-          --extensions=${{ inputs.extensions }} \
+        run: >-
+          cpp-linter
+          --version=14
+          --style=file
+          --tidy-checks="-*"
+          --files-changed-only=false
+          --step-summary=true
+          --extensions="${{ inputs.extensions }}"
           --ignore='${{ inputs.ignore }}'
       - name: Linter checks failed?
         if: steps.linter.outputs.checks-failed > 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ exclude: >
 repos:
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     - id: check-toml
     - id: check-yaml
@@ -21,17 +21,13 @@ repos:
     - id: mixed-line-ending
       args: ["--fix=lf"]
 
-  - repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-    - id: black
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.252
+    rev: v0.3.4
     hooks:
     - id: ruff
+    - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.0.1
+    rev: v1.9.0
     hooks:
     - id: mypy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name,too-few-public-methods
 """This file is for `sphinx-build` configuration"""
+
 import os
 from pathlib import Path
 import sys

--- a/examples/cpython/absolute_mode.py
+++ b/examples/cpython/absolute_mode.py
@@ -4,6 +4,7 @@ prints the values.
 
 See documentation at https://cirquepinnacle.rtfd.io/
 """
+
 import math
 import time
 from typing import Union

--- a/examples/cpython/anymeas_mode.py
+++ b/examples/cpython/anymeas_mode.py
@@ -4,6 +4,7 @@ prints the values.
 
 See documentation at https://cirquepinnacle.rtfd.io/
 """
+
 import time
 from typing import Union
 from cirque_pinnacle import (

--- a/examples/cpython/relative_mode.py
+++ b/examples/cpython/relative_mode.py
@@ -4,6 +4,7 @@ prints the values.
 
 See documentation at https://cirquepinnacle.rtfd.io/
 """
+
 import time
 from typing import Union
 from cirque_pinnacle import (

--- a/examples/linux/.clang-format
+++ b/examples/linux/.clang-format
@@ -67,10 +67,7 @@ DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat: false
 EmptyLineBeforeAccessModifier: Always
-# ---
-# only in v13+
-# EmptyLineAfterAccessModifier: Leave
-# ---
+EmptyLineAfterAccessModifier: Leave
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 IncludeBlocks: Preserve
@@ -89,10 +86,7 @@ IncludeCategories:
     CaseSensitive: false
 IncludeIsMainRegex: "(Test)?$"
 IncludeIsMainSourceRegex: ""
-# ---
-# only in v13+
-# IndentAccessModifiers: false
-# ---
+IndentAccessModifiers: false
 IndentCaseLabels: true
 IndentCaseBlocks: false
 IndentGotoLabels: false
@@ -117,15 +111,12 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
-# ---
-# only in v13+
-# ReferenceAlignment: Right
-# ---
+ReferenceAlignment: Pointer
 ReflowComments: true
-# ---
-# only in v13+
-# ShortNamespaceLines: 0
-# ---
+SpacesInLineCommentPrefix:
+  Maximum: -1
+  Minimum: 0
+ShortNamespaceLines: 0
 # Sort**** is about sorting include/using statements alphabetically
 SortIncludes: false
 SortUsingDeclarations: false

--- a/examples/linux/relative_mode.cpp
+++ b/examples/linux/relative_mode.cpp
@@ -31,7 +31,8 @@ bool setup()
         std::cout << "Cirque Pinnacle not responding!" << std::endl;
         return false;
     }
-    std::cout << "CirquePinnacle/examples/linux/relative_mode\n" << std::endl;
+    std::cout << "CirquePinnacle/examples/linux/relative_mode\n"
+              << std::endl;
 #ifndef USE_SW_DR // if using PINNACLE_SW_DR
     std::cout << "-- Using HW DataReady pin." << std::endl;
 #endif

--- a/examples/pico_sdk/.clang-format
+++ b/examples/pico_sdk/.clang-format
@@ -67,10 +67,7 @@ DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat: false
 EmptyLineBeforeAccessModifier: Always
-# ---
-# only in v13+
-# EmptyLineAfterAccessModifier: Leave
-# ---
+EmptyLineAfterAccessModifier: Leave
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 IncludeBlocks: Preserve
@@ -89,10 +86,7 @@ IncludeCategories:
     CaseSensitive: false
 IncludeIsMainRegex: "(Test)?$"
 IncludeIsMainSourceRegex: ""
-# ---
-# only in v13+
-# IndentAccessModifiers: false
-# ---
+IndentAccessModifiers: false
 IndentCaseLabels: true
 IndentCaseBlocks: false
 IndentGotoLabels: false
@@ -117,15 +111,12 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
-# ---
-# only in v13+
-# ReferenceAlignment: Right
-# ---
+ReferenceAlignment: Pointer
 ReflowComments: true
-# ---
-# only in v13+
-# ShortNamespaceLines: 0
-# ---
+SpacesInLineCommentPrefix:
+  Maximum: -1
+  Minimum: 0
+ShortNamespaceLines: 0
 # Sort**** is about sorting include/using statements alphabetically
 SortIncludes: false
 SortUsingDeclarations: false

--- a/examples/pico_sdk/defaultPins.h
+++ b/examples/pico_sdk/defaultPins.h
@@ -7,26 +7,26 @@
 #endif
 
 #if defined(ADAFRUIT_QTPY_RP2040)
-    #define SS_PIN PICO_DEFAULT_UART_RX_PIN // the pin labeled RX (GPIO5)
-    #ifndef DR_PIN // if not using PINNACLE_SW_DR
+    #define SS_PIN PICO_DEFAULT_UART_RX_PIN     // the pin labeled RX (GPIO5)
+    #ifndef DR_PIN                              // if not using PINNACLE_SW_DR
         #define DR_PIN PICO_DEFAULT_UART_TX_PIN // the pin labeled TX (GPIO20)
     #endif
 
 #elif defined(PIMORONI_TINY2040)
     #define SS_PIN PICO_DEFAULT_SPI_CSN_PIN // pin 5
-    #ifndef DR_PIN // if not using PINNACLE_SW_DR
-        #define DR_PIN 1 // pin 1
+    #ifndef DR_PIN                          // if not using PINNACLE_SW_DR
+        #define DR_PIN 1                    // pin 1
     #endif
 
 #elif defined(SPARFUN_THINGPLUS)
-    #define SS_PIN 21 // the pin labeled 21
-    #ifndef DR_PIN // if not using PINNACLE_SW_DR
+    #define SS_PIN 21     // the pin labeled 21
+    #ifndef DR_PIN        // if not using PINNACLE_SW_DR
         #define DR_PIN 22 // the pin labeled 22
     #endif
 
 #elif defined(ADAFRUIT_ITSYBITSY_RP2040)
-    #define SS_PIN 12 // the pin labeled 2
-    #ifndef DR_PIN // if not using PINNACLE_SW_DR
+    #define SS_PIN 12    // the pin labeled 2
+    #ifndef DR_PIN       // if not using PINNACLE_SW_DR
         #define DR_PIN 6 // the pin labeled 7
     #endif
 

--- a/examples/pico_sdk/usb_mouse/main.cpp
+++ b/examples/pico_sdk/usb_mouse/main.cpp
@@ -80,7 +80,7 @@ int main(void)
     trackpad.setDataMode(PINNACLE_RELATIVE); // ensure mouse mode is enabled
     // tell the Pinnacle ASIC to rotate the orientation of the axis data by +90 degrees
     trackpad.relativeModeConfig(true, true); // (enable taps, rotate90)
-    trackpad.allowSleep(true); // let power consumption drop if inactive for 5 seconds
+    trackpad.allowSleep(true);               // let power consumption drop if inactive for 5 seconds
 
     while (1)
     {

--- a/examples/relative_mode/relative_mode.ino
+++ b/examples/relative_mode/relative_mode.ino
@@ -28,7 +28,7 @@ void setup() {
   }
   Serial.println(F("CirquePinnacle/examples/relative_mode"));
   trackpad.setDataMode(PINNACLE_RELATIVE);
-  trackpad.relativeModeConfig(); // uses default config
+  trackpad.relativeModeConfig();  // uses default config
   Serial.println(F("Touch the trackpad to see the data."));
 }
 

--- a/examples/usb_mouse/usb_mouse.ino
+++ b/examples/usb_mouse/usb_mouse.ino
@@ -12,9 +12,9 @@ PinnacleTouchSPI trackpad(DR_PIN, SS_PIN);
 // an object to hold data reported by the Cirque trackpad
 RelativeReport data;
 
-const uint32_t interval = 750; // milliseconds used to blink LED
-uint32_t lastLedChange = 0;  // millis() since last digitalWrite()
-bool ledState = false;  // last state sent to digitalWrite()
+const uint32_t interval = 750;  // milliseconds used to blink LED
+uint32_t lastLedChange = 0;     // millis() since last digitalWrite()
+bool ledState = false;          // last state sent to digitalWrite()
 
 void setup() {
   pinMode(LED, OUTPUT);

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """Build & Install script for the CirquePinnacle C++ library python wrappers."""
+
 import os
 import platform
 import subprocess

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -67,10 +67,7 @@ DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat: false
 EmptyLineBeforeAccessModifier: Always
-# ---
-# only in v13+
-# EmptyLineAfterAccessModifier: Leave
-# ---
+EmptyLineAfterAccessModifier: Leave
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 IncludeBlocks: Preserve
@@ -89,10 +86,7 @@ IncludeCategories:
     CaseSensitive: false
 IncludeIsMainRegex: "(Test)?$"
 IncludeIsMainSourceRegex: ""
-# ---
-# only in v13+
-# IndentAccessModifiers: false
-# ---
+IndentAccessModifiers: false
 IndentCaseLabels: true
 IndentCaseBlocks: false
 IndentGotoLabels: false
@@ -117,15 +111,12 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PenaltyIndentedWhitespace: 0
 PointerAlignment: Left
-# ---
-# only in v13+
-# ReferenceAlignment: Right
-# ---
+ReferenceAlignment: Pointer
 ReflowComments: true
-# ---
-# only in v13+
-# ShortNamespaceLines: 0
-# ---
+SpacesInLineCommentPrefix:
+  Maximum: -1
+  Minimum: 0
+ShortNamespaceLines: 0
 # Sort**** is about sorting include/using statements alphabetically
 SortIncludes: false
 SortUsingDeclarations: false

--- a/src/CirquePinnacle.cpp
+++ b/src/CirquePinnacle.cpp
@@ -420,7 +420,7 @@ void PinnacleTouch::startMeasureAdc(unsigned int bitsToToggle, unsigned int togg
             buffer[3 - i + 4] = (uint8_t)(togglePolarity >> (i * 8));
         }
         rapWriteBytes(PINNACLE_PACKET_BYTE_1, buffer, 8);
-        buffer[0] = 0; // clearStatusFlags()
+        buffer[0] = 0;    // clearStatusFlags()
         buffer[1] = 0x18; // initiate measurements
         rapWriteBytes(PINNACLE_STATUS, buffer, 2);
     }

--- a/src/CirquePinnacle_common.h
+++ b/src/CirquePinnacle_common.h
@@ -49,7 +49,6 @@
         #define PINNACLE_SPI_SPEED 6000000
     #endif
 
-
 /**
  * alias for SPI bus implementation
  *

--- a/src/utility/bcm2xxx/spi.cpp
+++ b/src/utility/bcm2xxx/spi.cpp
@@ -28,92 +28,92 @@ extern "C" {
 
 namespace cirque_pinnacle_arduino_wrappers {
 
-static pthread_mutex_t spiMutex0 = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t spiMutex1 = PTHREAD_MUTEX_INITIALIZER;
+    static pthread_mutex_t spiMutex0 = PTHREAD_MUTEX_INITIALIZER;
+    static pthread_mutex_t spiMutex1 = PTHREAD_MUTEX_INITIALIZER;
 
-SPIClass::SPIClass() : busID(PINNACLE_DEFAULT_SPI_BUS)
-{
-}
+    SPIClass::SPIClass() : busID(PINNACLE_DEFAULT_SPI_BUS)
+    {
+    }
 
-void SPIClass::begin(int busNumber)
-{
-    if (spiInitialized && busNumber != busID)
+    void SPIClass::begin(int busNumber)
+    {
+        if (spiInitialized && busNumber != busID)
+            end();
+        if (busID >= 10)
+            bcm2835_aux_spi_begin();
+        else
+            bcm2835_spi_begin();
+        spiInitialized = true;
+        busID = busNumber;
+    }
+
+    void SPIClass::end()
+    {
+        if (busID >= 10)
+            bcm2835_aux_spi_end();
+        else
+            bcm2835_spi_end();
+        spiInitialized = false;
+    }
+
+    void SPIClass::beginTransaction(SPISettings settings)
+    {
+        if (geteuid() != 0) {
+            throw SPIException("Process should run as root");
+        }
+        if (busID >= 10)
+            pthread_mutex_lock(&spiMutex1);
+        else
+            pthread_mutex_lock(&spiMutex0);
+        bcm2835_spi_setBitOrder(settings.bitOrder);
+        bcm2835_spi_setDataMode(settings.mode);
+        bcm2835_spi_set_speed_hz(settings.clock);
+        if (busID >= 10) {
+            // bcm2835 lib does not provide support for chip select on the auxilary SPI bus.
+            // brute force via GPIO API instead (not nearly as fast)
+            digitalWrite(18 - (busID & 3), LOW);
+        }
+        else
+            bcm2835_spi_chipSelect((uint8_t)(busID & 3));
+    }
+
+    void SPIClass::endTransaction()
+    {
+        if (busID >= 10) {
+            digitalWrite(18 - (busID & 3), HIGH);
+            pthread_mutex_unlock(&spiMutex1);
+        }
+        else
+            pthread_mutex_unlock(&spiMutex0);
+    }
+
+    void SPIClass::transfer(void* tx_buf, void* rx_buf, uint32_t len)
+    {
+        if (busID >= 10)
+            bcm2835_aux_spi_transfernb((char*)tx_buf, (char*)rx_buf, len);
+        else
+            bcm2835_spi_transfernb((char*)tx_buf, (char*)rx_buf, len);
+    }
+
+    void SPIClass::transfer(void* buf, uint32_t len)
+    {
+        bcm2835_spi_transfern((char*)buf, len);
+    }
+
+    uint8_t SPIClass::transfer(uint8_t tx)
+    {
+        if (busID >= 10)
+            return bcm2835_aux_spi_transfer(tx);
+        else
+            return bcm2835_spi_transfer(tx);
+    }
+
+    SPIClass::~SPIClass()
+    {
         end();
-    if (busID >= 10)
-        bcm2835_aux_spi_begin();
-    else
-        bcm2835_spi_begin();
-    spiInitialized = true;
-    busID = busNumber;
-}
-
-void SPIClass::end()
-{
-    if (busID >= 10)
-        bcm2835_aux_spi_end();
-    else
-        bcm2835_spi_end();
-    spiInitialized = false;
-}
-
-void SPIClass::beginTransaction(SPISettings settings)
-{
-    if (geteuid() != 0) {
-        throw SPIException("Process should run as root");
     }
-    if (busID >= 10)
-        pthread_mutex_lock(&spiMutex1);
-    else
-        pthread_mutex_lock(&spiMutex0);
-    bcm2835_spi_setBitOrder(settings.bitOrder);
-    bcm2835_spi_setDataMode(settings.mode);
-    bcm2835_spi_set_speed_hz(settings.clock);
-    if (busID >= 10) {
-        // bcm2835 lib does not provide support for chip select on the auxilary SPI bus.
-        // brute force via GPIO API instead (not nearly as fast)
-        digitalWrite(18 - (busID & 3), LOW);
-    }
-    else
-        bcm2835_spi_chipSelect((uint8_t)(busID & 3));
-}
 
-void SPIClass::endTransaction()
-{
-    if (busID >= 10) {
-        digitalWrite(18 - (busID & 3), HIGH);
-        pthread_mutex_unlock(&spiMutex1);
-    }
-    else
-        pthread_mutex_unlock(&spiMutex0);
-}
-
-void SPIClass::transfer(void* tx_buf, void* rx_buf, uint32_t len)
-{
-    if (busID >= 10)
-        bcm2835_aux_spi_transfernb((char*)tx_buf, (char*)rx_buf, len);
-    else
-        bcm2835_spi_transfernb((char*)tx_buf, (char*)rx_buf, len);
-}
-
-void SPIClass::transfer(void* buf, uint32_t len)
-{
-    bcm2835_spi_transfern((char*)buf, len);
-}
-
-uint8_t SPIClass::transfer(uint8_t tx)
-{
-    if (busID >= 10)
-        return bcm2835_aux_spi_transfer(tx);
-    else
-        return bcm2835_spi_transfer(tx);
-}
-
-SPIClass::~SPIClass()
-{
-    end();
-}
-
-SPIClass SPI;
+    SPIClass SPI;
 
 } // namespace cirque_pinnacle_arduino_wrappers
 

--- a/src/utility/bcm2xxx/time_keeping.cpp
+++ b/src/utility/bcm2xxx/time_keeping.cpp
@@ -26,14 +26,14 @@ extern "C" {
 
 namespace cirque_pinnacle_arduino_wrappers {
 
-auto start = std::chrono::steady_clock::now();
+    auto start = std::chrono::steady_clock::now();
 
-uint32_t __millis()
-{
-    auto end = std::chrono::steady_clock::now();
+    uint32_t __millis()
+    {
+        auto end = std::chrono::steady_clock::now();
 
-    return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
-}
+        return std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    }
 
 } // namespace cirque_pinnacle_arduino_wrappers
 

--- a/src/utility/bcm2xxx/time_keeping.h
+++ b/src/utility/bcm2xxx/time_keeping.h
@@ -28,9 +28,9 @@ extern "C" {
 
 namespace cirque_pinnacle_arduino_wrappers {
 
-// the bcm2835.h defines the following functions for us: `delay()`, `delayMicroseconds()`
+    // the bcm2835.h defines the following functions for us: `delay()`, `delayMicroseconds()`
 
-uint32_t __millis();
+    uint32_t __millis();
 
     #define millis() __millis()
 

--- a/src/utility/linux_kernel/spi.cpp
+++ b/src/utility/linux_kernel/spi.cpp
@@ -47,8 +47,8 @@ namespace cirque_pinnacle_arduino_wrappers {
         }
 
         /* set spidev accordingly to busNumber like:
-     * busNumber = 23 -> /dev/spidev2.3
-     */
+         * busNumber = 23 -> /dev/spidev2.3
+         */
         char device[] = "/dev/spidev0.0";
         device[11] += (busNumber / 10) % 10;
         device[13] += busNumber % 10;

--- a/src/utility/template/spi.h
+++ b/src/utility/template/spi.h
@@ -150,9 +150,9 @@ public:
         init(PINNACLE_SPI_SPEED, MSBFIRST, SPI_MODE1);
     }
 
-    uint32_t clock; ///< The SPI bus clock speed (in Hz).
+    uint32_t clock;    ///< The SPI bus clock speed (in Hz).
     BitOrder bitOrder; ///< The SPI bus byte order (endianess).
-    DataMode mode; ///< The SPI bus mode (clock polarity/phase).
+    DataMode mode;     ///< The SPI bus mode (clock polarity/phase).
 
 private:
     void init(uint32_t _clock, BitOrder _bitOrder, DataMode _dataMode)

--- a/src/utility/template/time_keeping.h
+++ b/src/utility/template/time_keeping.h
@@ -28,11 +28,11 @@ extern "C" {
 
 namespace cirque_pinnacle_arduino_wrappers {
 
-void __msleep(int milliseconds);
+    void __msleep(int milliseconds);
 
-void __usleep(int microseconds);
+    void __usleep(int microseconds);
 
-uint32_t __millis();
+    uint32_t __millis();
 
     #define delay(ms)             __msleep(ms)
     #define delayMicroseconds(us) __usleep(us)


### PR DESCRIPTION
- includes changes to .clang-format config
- ran clang-format on incorrectly formatted sources
- updated erroneous ignore pattern in CI workflows
- upgraded pre-commit hooks
- switch from black to to ruff for formatting python sources
- ran `ruff format` on python files
- format Arduino examples
- update CI triggers
- update all actions used in CI
