### PR TITLE
expose selected driver in python binding

### DIFF
--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -8,6 +8,7 @@ on:
       - "examples/**/*.ino"
       - "src/*.h"
       - "src/*.cpp"
+      - "!src/py_bindings.cpp"
   push:
     branches: [master]
     paths:

--- a/examples/cpython/absolute_mode.py
+++ b/examples/cpython/absolute_mode.py
@@ -14,6 +14,7 @@ from cirque_pinnacle import (
     PinnacleTouchI2C,
     PINNACLE_SW_DR,
     PINNACLE_ABSOLUTE,
+    PINNACLE_DRIVER,
 )
 
 print("CirquePinnacle/examples/cpython/absolute_mode")
@@ -22,7 +23,10 @@ print("CirquePinnacle/examples/cpython/absolute_mode")
 dr_pin = PINNACLE_SW_DR  # uses internal DR flag
 if not input("Use SW Data Ready? [y/N] ").lower().startswith("y"):
     print("-- Using HW Data Ready pin.")
-    dr_pin = 25  # GPIO25 (pin 22 if using MRAA driver)
+    if PINNACLE_DRIVER == "mraa":
+        dr_pin = 22  # GPIO25
+    else:
+        dr_pin = 25  # GPIO25
 
 trackpad: Union[PinnacleTouchSPI, PinnacleTouchI2C]
 if not input("Is the trackpad configured for I2C? [y/N] ").lower().startswith("y"):

--- a/examples/cpython/anymeas_mode.py
+++ b/examples/cpython/anymeas_mode.py
@@ -11,11 +11,15 @@ from cirque_pinnacle import (
     PinnacleTouchSPI,
     PinnacleTouchI2C,  # noqa: imported but unused
     PINNACLE_ANYMEAS,
+    PINNACLE_DRIVER,
 )
 
 print("CirquePinnacle/examples/cpython/anymeas_mode\n")
 
-dr_pin = 25  # GPIO25 (pin 22 if using MRAA driver)
+if PINNACLE_DRIVER == "mraa":
+    dr_pin = 22  # GPIO25
+else:
+    dr_pin = 25  # GPIO25
 
 trackpad: Union[PinnacleTouchSPI, PinnacleTouchI2C]
 if not input("Is the trackpad configured for I2C? [y/N] ").lower().startswith("y"):

--- a/examples/cpython/relative_mode.py
+++ b/examples/cpython/relative_mode.py
@@ -12,6 +12,7 @@ from cirque_pinnacle import (
     PinnacleTouchSPI,
     PinnacleTouchI2C,
     PINNACLE_SW_DR,
+    PINNACLE_DRIVER,
 )
 
 print("CirquePinnacle/examples/cpython/relative_mode\n")
@@ -20,7 +21,10 @@ print("CirquePinnacle/examples/cpython/relative_mode\n")
 dr_pin = PINNACLE_SW_DR  # uses internal DR flag
 if not input("Use SW Data Ready? [y/N] ").lower().startswith("y"):
     print("-- Using HW Data Ready pin.")
-    dr_pin = 25  # GPIO25 (pin 22 if using MRAA driver)
+    if PINNACLE_DRIVER == "mraa":
+        dr_pin = 22  # GPIO25
+    else:
+        dr_pin = 25  # GPIO25
 
 trackpad: Union[PinnacleTouchSPI, PinnacleTouchI2C]
 if not input("Is the trackpad configured for I2C? [y/N] ").lower().startswith("y"):

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,10 @@ else() # if(${PINNACLE_PY_BINDING})
         utility/includes.h
         ${PINNACLE_DRIVER_SOURCES}
     )
+    # expose the selected driver in the python binding
+    target_compile_definitions(cirque_pinnacle PUBLIC
+        PINNACLE_DRIVER="${PINNACLE_DRIVER}"
+    )
 
     if(DEFINED PINNACLE_SPI_SPEED)
         message(STATUS "PINNACLE_SPI_SPEED set to ${PINNACLE_SPI_SPEED}")

--- a/src/cirque_pinnacle-stubs/__init__.pyi
+++ b/src/cirque_pinnacle-stubs/__init__.pyi
@@ -17,6 +17,7 @@
 from typing import List, overload
 
 PINNACLE_SW_DR: int = ...
+PINNACLE_DRIVER: str = ...
 
 class PinnacleDataMode:
     @property

--- a/src/py_bindings.cpp
+++ b/src/py_bindings.cpp
@@ -98,6 +98,7 @@ void setCalibrationMatrix_wrapper(PinnacleTouch* self, py::list& matrix)
 PYBIND11_MODULE(cirque_pinnacle, m)
 {
     m.attr("PINNACLE_SW_DR") = PINNACLE_SW_DR;
+    m.attr("PINNACLE_DRIVER") = PINNACLE_DRIVER;
 
     // ******************** expose PinnacleDataMode
     py::enum_<PinnacleDataMode> dataMode(m, "PinnacleDataMode");


### PR DESCRIPTION
- adds `cirque_pinnacle.PINNACLE_DRIVER` string attr to python binding
- uses new attr to dynamically declare pins in examples/cpython*.py
