### PR TITLE
Support picoSDK v2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,13 @@
 version: 2
+
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.11"
+    python: "latest"
 python:
   install:
     - requirements: docs/requirements.txt

--- a/src/utility/rp2/i2c.h
+++ b/src/utility/rp2/i2c.h
@@ -31,7 +31,7 @@ extern "C" {
 namespace cirque_pinnacle_arduino_wrappers {
 
     #ifdef PICO_DEFAULT_I2C_INSTANCE
-        #define PINNACLE_DEFAULT_I2C_BUS PICO_DEFAULT_I2C_INSTANCE
+        #define PINNACLE_DEFAULT_I2C_BUS PICO_DEFAULT_I2C_INSTANCE()
     #else
         #define PINNACLE_DEFAULT_I2C_BUS i2c0
     #endif

--- a/src/utility/rp2/spi.h
+++ b/src/utility/rp2/spi.h
@@ -35,7 +35,7 @@ namespace cirque_pinnacle_arduino_wrappers {
     #endif
 
     #ifdef PICO_DEFAULT_SPI_INSTANCE
-        #define PINNACLE_DEFAULT_SPI_BUS PICO_DEFAULT_SPI_INSTANCE
+        #define PINNACLE_DEFAULT_SPI_BUS PICO_DEFAULT_SPI_INSTANCE()
     #else
         #define PINNACLE_DEFAULT_SPI_BUS spi0
     #endif


### PR DESCRIPTION
The macros for declaring default SPI and I2C bus instances have changed to a function in PicoSDK v2.

This should not affect user-space code, but it does drop support for picoSDK v1.x