### PR TITLE
bump pybind11 to v2.13.6

### DIFF
--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -152,7 +152,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-    needs: [source-dist, linux-wheels]
+    needs: [lint, source-dist, linux-wheels]
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Save distributable source as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "cirque_pinnacle-sdist"
+          name: "cirque_pinnacle-dist_source"
           path: ${{ github.workspace }}/dist
 
   build_linux:

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -68,6 +68,9 @@ jobs:
           name: "cirque_pinnacle-dist_source"
           path: ${{ github.workspace }}/dist
 
+      - name: Try install from source distributable
+        run: pip install sdist/*.tar.gz -v
+
   build_linux:
     runs-on: ubuntu-latest
     needs: [check_source]
@@ -89,15 +92,6 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install twine
 
-      - name: Fetch distributable source artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: "cirque_pinnacle-dist_source"
-          path: ${{ github.workspace }}/sdist
-
-      - name: Try install from source distributable
-        run: pip install sdist/*.tar.gz -v
-
       - name: Checkout Current Repo
         uses: actions/checkout@v4
         with:
@@ -117,7 +111,7 @@ jobs:
           image: docker.io/tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build binary wheels with cibuildwheels
-        uses: pypa/cibuildwheel@v2.21.2
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.platform }}
           CIBW_SKIP: pp* *ppc64le *s390x
@@ -159,11 +153,11 @@ jobs:
 
       - name: Publish package (to TestPyPI)
         if: github.event_name == 'workflow_dispatch'
-        uses: pypa/gh-action-pypi-publish@v1.10.3
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           repository-url: https://test.pypi.org/legacy/
 
       - name: Publish to PyPi
         # only upload distributions to PyPi when triggered by a published release
         if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.10.3
+        uses: pypa/gh-action-pypi-publish@v1.12.4

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -89,13 +89,31 @@ jobs:
       - name: Try install from source distributable
         run: pip install dist/*.tar.gz -v
 
+  bin-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      version-matrix: ${{ steps.matrix-out.outputs.versions }}
+    steps:
+      - name: create matrix
+        id: matrix-out
+        shell: python
+        run: |
+          from os import environ
+          import json
+          versions = ["cp313"]
+          if "${{github.event_name != 'pull_request'}}" == "true":
+              versions.extend(["cp37", "cp38", "cp39", "cp310", "cp311", "cp312"])
+          with open(environ["GITHUB_OUTPUT"], mode="a", encoding="utf-8") as gh_out:
+              gh_out.write(f'versions={json.dumps(versions)}\n')
+
   linux-wheels:
     runs-on: ubuntu-latest
+    needs: [bin-matrix]
     strategy:
       fail-fast: false
       matrix:
         platform: [native, aarch64, armv7l]
-        python: [cp37, cp38, cp39, cp310, cp311, cp312, cp313]
+        python: ${{ fromJSON(needs.bin-matrix.outputs.version-matrix) }}
         tag: [manylinux, musllinux]
     steps:
       - name: Set up Python

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -28,7 +28,7 @@ on:
       - ".github/workflows/build_python.yml"
 
 jobs:
-  check_source:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
@@ -43,11 +43,8 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Install pre-commit, twine, and lib stubs
-        run: pip install pre-commit twine build .
-
-      - name: Create source distribution
-        run: python -m build -s
+      - name: Install pre-commit and lib stubs
+        run: pip install pre-commit .
 
       - name: Cache pre-commit venv
         uses: actions/cache@v4
@@ -57,6 +54,27 @@ jobs:
 
       - name: run pre-commit on all files
         run: pre-commit run --all-files
+
+  source-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python
+        id: python-setup
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Checkout Current Repo
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Install twine and build
+        run: pip install twine build
+
+      - name: Create source distribution
+        run: python -m build -s
 
       - name: Checks distributable with twine
         shell: bash
@@ -71,9 +89,8 @@ jobs:
       - name: Try install from source distributable
         run: pip install dist/*.tar.gz -v
 
-  build_linux:
+  linux-wheels:
     runs-on: ubuntu-latest
-    needs: [check_source]
     strategy:
       fail-fast: false
       matrix:
@@ -135,7 +152,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-    needs: [check_source, build_linux]
+    needs: [source-dist, linux-wheels]
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -71,8 +71,12 @@ jobs:
   build_linux:
     runs-on: ubuntu-latest
     needs: [check_source]
-    env:
-      BUILD_ARCH: native
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [native, aarch64, armv7l]
+        python: [cp37, cp38, cp39, cp310, cp311, cp312, cp313]
+        tag: [manylinux, musllinux]
     steps:
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -88,7 +92,7 @@ jobs:
       - name: Fetch distributable source artifact
         uses: actions/download-artifact@v4
         with:
-          name: "cirque_pinnacle-sdist"
+          name: "cirque_pinnacle-dist_source"
           path: ${{ github.workspace }}/sdist
 
       - name: Try install from source distributable
@@ -100,19 +104,25 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Build aarch64 and armv7l?
-        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-        run: echo "BUILD_ARCH=aarch64 armv7l ${{ env.BUILD_ARCH }}" >> $GITHUB_ENV
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        if: contains(env.BUILD_ARCH, 'aarch64')
+        if: matrix.platform == 'aarch64' || matrix.platform == 'armv7l'
+        with:
+          # cached image is enabled by default.
+          # This option to disable caching doesn't exist before docker/setup-qemu-action@v3.3
+          # cache-image: false
+
+          # NOTE: the default tag `tonistiigi/binfmt:latest` is old and uses qemu v6.2.0
+          # See also https://github.com/tonistiigi/binfmt/issues/215
+          image: docker.io/tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Build binary wheels with cibuildwheels
         uses: pypa/cibuildwheel@v2.21.2
         env:
-          CIBW_ARCHS_LINUX: ${{ env.BUILD_ARCH }}
-          CIBW_SKIP: cp36* pp* *ppc64le *s390x
+          CIBW_ARCHS_LINUX: ${{ matrix.platform }}
+          CIBW_SKIP: pp* *ppc64le *s390x
+          CIBW_BUILD_VERBOSITY: 1
+          CIBW_BUILD: '${{ matrix.python }}*${{ matrix.tag }}*'
 
       - name: Move cross-compiled wheels to dist folder
         run: |
@@ -125,7 +135,7 @@ jobs:
       - name: Save distributable wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: "cirque_pinnacle-bdist"
+          name: "cirque_pinnacle-dist_${{ matrix.platform }}_${{ matrix.python }}_${{ matrix.tag }}"
           path: ${{ github.workspace }}/dist
 
   release:
@@ -140,22 +150,12 @@ jobs:
         with:
           python-version: 3.x
 
-      - name: Fetch distributable wheel artifacts
+      - name: Fetch built distribution artifacts
         uses: actions/download-artifact@v4
         with:
-          name: "cirque_pinnacle-bdist"
+          pattern: "cirque_pinnacle-dist*"
           path: ${{ github.workspace }}/dist
-
-      - name: Fetch distributable source artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: "cirque_pinnacle-sdist"
-          path: ${{ github.workspace }}/dist
-
-      - name: Install dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install twine
+          merge-multiple: true
 
       - name: Publish package (to TestPyPI)
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/build_python.yml
+++ b/.github/workflows/build_python.yml
@@ -69,7 +69,7 @@ jobs:
           path: ${{ github.workspace }}/dist
 
       - name: Try install from source distributable
-        run: pip install sdist/*.tar.gz -v
+        run: pip install dist/*.tar.gz -v
 
   build_linux:
     runs-on: ubuntu-latest

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -9,6 +9,7 @@ words:
   - armv
   - baudrate
   - bdist
+  - binfmt
   - bndy
   - cibuildwheels
   - CIBW
@@ -36,7 +37,9 @@ words:
   - linenos
   - literalinclude
   - Makefiles
+  - manylinux
   - MOSI
+  - musllinux
   - Muxing
   - Ofast
   - pico
@@ -62,6 +65,7 @@ words:
   - STREQUAL
   - tinyusb
   - toctree
+  - tonistiigi
   - trackpad
   - trackpads
   - venv


### PR DESCRIPTION
This uses a CI matrix to build Python distributions, which should reduce the amount of time it takes to run the Python CI workflow. Runs in a PR will only build a limited number of binary wheels. Runs in a `push` (to master branch), `release` or `workflow_dispatch` event will build all distributed binary wheels.