### PR TITLE
follow up to #33

### DIFF
--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -44,7 +44,6 @@ jobs:
           - "arduino:samd:mkrwifi1010"
           - "arduino:samd:nano_33_iot"
           - "arduino:samd:adafruit_circuitplayground_m0"
-          # - "arduino:samd:tian"
         # By default, don't generate size deltas data.
         enable-deltas-report:
           - false

--- a/cspell.config.yml
+++ b/cspell.config.yml
@@ -8,12 +8,14 @@ words:
   - armhf
   - armv
   - ASIC
+  - atmegang
   - baudrate
   - bdist
   - binfmt
   - bndy
   - cibuildwheels
   - CIBW
+  - circuitplayground
   - cirquepinnacle
   - cpack
   - CPHA
@@ -29,6 +31,7 @@ words:
   - DPYTHON
   - eabi
   - endforeach
+  - fqbn
   - ftime
   - gnueabihf
   - gpiochip
@@ -43,6 +46,10 @@ words:
   - LSBFIRST
   - Makefiles
   - manylinux
+  - mbed
+  - megaavr
+  - mkrwifi
+  - mkrzero
   - MOSI
   - MSBFIRST
   - musllinux
@@ -62,6 +69,7 @@ words:
   - qtpy
   - raspberrypi
   - repr
+  - samd
   - sdist
   - seealso
   - setuptools
@@ -80,5 +88,6 @@ words:
   - tonistiigi
   - trackpad
   - trackpads
+  - unowifi
   - venv
   - viewcode

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,13 @@ project(cirque_pinnacle C CXX)
 # optionally enable building the python binding
 option(PINNACLE_PY_BINDING "Only build python binding" OFF) # enabled via setup.py
 option(PINNACLE_ANYMEAS_SUPPORT "Enable anymeas mode support" ON)
-option(PINNACLE_DEV_HW_DEBUG "Expose register read function" OFF)
+option(PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    "Allow experimental ERA functionality on trackpads with newer firmware.
+    To use this feature, C++ inheritance shall be used
+    because the ERA functions are private.
+    Does not apply to the Python binding."
+    OFF
+)
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/StandardProjectSettings.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/PreventInSourceBuilds.cmake)
@@ -113,9 +119,9 @@ if(NOT PINNACLE_PY_BINDING)
         target_compile_definitions(${LibTargetName} PUBLIC PINNACLE_ANYMEAS_SUPPORT=0)
     endif()
 
-    if(PINNACLE_DEV_HW_DEBUG)
-        message(STATUS "Exposing debug function: readRegisters(regOffset, buf, count)")
-        target_compile_definitions(${LibTargetName} PUBLIC PINNACLE_DEV_HW_DEBUG=1)
+    if (PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE)
+        message(STATUS "Allowing experimental ERA functionality on newer trackpads")
+        target_compile_definitions(${LibTargetName} PUBLIC PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE=1)
     endif()
 
     target_link_libraries(${LibTargetName} INTERFACE

--- a/src/CirquePinnacle.cpp
+++ b/src/CirquePinnacle.cpp
@@ -124,10 +124,7 @@ PinnacleDataMode PinnacleTouch::getDataMode()
 
 bool PinnacleTouch::isRev2025()
 {
-    if (_dataMode != PINNACLE_ERROR) {
-        return _rev2025;
-    }
-    return false;
+    return _rev2025;
 }
 
 bool PinnacleTouch::isHardConfigured()

--- a/src/CirquePinnacle.cpp
+++ b/src/CirquePinnacle.cpp
@@ -441,12 +441,12 @@ int16_t PinnacleTouch::getMeasureAdc()
 
 void PinnacleTouch::eraWrite(uint16_t registerAddress, uint8_t registerValue)
 {
-    PINNACLE_USE_ARDUINO_API
     bool prevFeedState = isFeedEnabled();
     if (prevFeedState) {
         feedEnabled(false); // accessing raw memory, so do this
     }
 #ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    PINNACLE_USE_ARDUINO_API
     if (_rev2025) {
         clearStatusFlags();
     }
@@ -478,12 +478,12 @@ void PinnacleTouch::eraWrite(uint16_t registerAddress, uint8_t registerValue)
 void PinnacleTouch::eraWriteBytes(uint16_t registerAddress, uint8_t registerValue, uint8_t repeat)
 {
     // NOTE this is rarely used as it only writes 1 value to multiple registers
-    PINNACLE_USE_ARDUINO_API
     bool prevFeedState = isFeedEnabled();
     if (prevFeedState) {
         feedEnabled(false); // accessing raw memory, so do this
     }
 #ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    PINNACLE_USE_ARDUINO_API
     if (_rev2025) {
         clearStatusFlags();
     }
@@ -516,12 +516,12 @@ void PinnacleTouch::eraWriteBytes(uint16_t registerAddress, uint8_t registerValu
 
 void PinnacleTouch::eraRead(uint16_t registerAddress, uint8_t* data)
 {
-    PINNACLE_USE_ARDUINO_API
     bool prevFeedState = isFeedEnabled();
     if (prevFeedState) {
         feedEnabled(false); // accessing raw memory, so do this
     }
 #ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    PINNACLE_USE_ARDUINO_API
     if (_rev2025) {
         clearStatusFlags();
     }
@@ -552,12 +552,12 @@ void PinnacleTouch::eraRead(uint16_t registerAddress, uint8_t* data)
 
 void PinnacleTouch::eraReadBytes(uint16_t registerAddress, uint8_t* data, uint8_t registerCount)
 {
-    PINNACLE_USE_ARDUINO_API
     bool prevFeedState = isFeedEnabled();
     if (prevFeedState) {
         feedEnabled(false); // accessing raw memory, so do this
     }
 #ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    PINNACLE_USE_ARDUINO_API
     if (_rev2025) {
         clearStatusFlags();
     }

--- a/src/CirquePinnacle.cpp
+++ b/src/CirquePinnacle.cpp
@@ -22,7 +22,7 @@
     #include <cstring> // memcpy(), memset()
 #endif
 
-PinnacleTouch::PinnacleTouch(pinnacle_gpio_t dataReadyPin) : _dataReady(dataReadyPin), _rev2025(false)
+PinnacleTouch::PinnacleTouch(pinnacle_gpio_t dataReadyPin) : _dataMode(PINNACLE_ERROR), _rev2025(false), _dataReady(dataReadyPin)
 {
     PINNACLE_USE_ARDUINO_API
     pinMode(_dataReady, INPUT);
@@ -40,17 +40,8 @@ bool PinnacleTouch::begin()
         buffer[0] = 0; // config power (defaults) and disable anymeas flags
         buffer[1] = 0; // config absolute mode defaults and disable feed
         rapWriteBytes(PINNACLE_SYS_CONFIG, buffer, 3);
-        if (!_rev2025) {
-            detectFingerStylus(); // detects both finger & stylus; sets sample rate to 100
-        }
-        else {
-            setSampleRate(100);
-        }
+        setSampleRate(100);
         rapWrite(PINNACLE_Z_IDLE, 30); // 30 z-idle packets
-        if (!_rev2025) {
-            setAdcGain(0);         // most sensitive attenuation
-            tuneEdgeSensitivity(); // because "why not?" (may only be beneficial if using an overlay)
-        }
         while (available()) {
             clearStatusFlags(); // ignore/discard all pending measurements waiting to be read()
         }
@@ -133,7 +124,10 @@ PinnacleDataMode PinnacleTouch::getDataMode()
 
 bool PinnacleTouch::isRev2025()
 {
-    return _rev2025;
+    if (_dataMode != PINNACLE_ERROR) {
+        return _rev2025;
+    }
+    return false;
 }
 
 bool PinnacleTouch::isHardConfigured()
@@ -450,17 +444,34 @@ int16_t PinnacleTouch::getMeasureAdc()
 
 void PinnacleTouch::eraWrite(uint16_t registerAddress, uint8_t registerValue)
 {
+    PINNACLE_USE_ARDUINO_API
     bool prevFeedState = isFeedEnabled();
     if (prevFeedState) {
         feedEnabled(false); // accessing raw memory, so do this
     }
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    if (_rev2025) {
+        clearStatusFlags();
+    }
+#endif
     rapWrite(PINNACLE_ERA_VALUE, registerValue);
     uint8_t buffer[2] = {(uint8_t)(registerAddress >> 8), (uint8_t)(registerAddress & 0xFF)};
     rapWriteBytes(PINNACLE_ERA_ADDR, buffer, 2);
     rapWrite(PINNACLE_ERA_CONTROL, 2); // indicate writing only 1 byte
-    do {
-        rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
-    } while (buffer[0]);
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    if (!_rev2025) {
+#endif
+        do {
+            rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
+        } while (buffer[0]);
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    }
+    else {
+        while (!digitalRead(_dataReady))
+        {
+        }
+    }
+#endif
     clearStatusFlags(); // clear Command Complete flag in Status register
     if (prevFeedState) {
         feedEnabled(prevFeedState); // resume previous feed state
@@ -470,18 +481,35 @@ void PinnacleTouch::eraWrite(uint16_t registerAddress, uint8_t registerValue)
 void PinnacleTouch::eraWriteBytes(uint16_t registerAddress, uint8_t registerValue, uint8_t repeat)
 {
     // NOTE this is rarely used as it only writes 1 value to multiple registers
+    PINNACLE_USE_ARDUINO_API
     bool prevFeedState = isFeedEnabled();
     if (prevFeedState) {
         feedEnabled(false); // accessing raw memory, so do this
     }
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    if (_rev2025) {
+        clearStatusFlags();
+    }
+#endif
     rapWrite(PINNACLE_ERA_VALUE, registerValue);
     uint8_t buffer[2] = {(uint8_t)(registerAddress >> 8), (uint8_t)(registerAddress & 0xFF)};
     rapWriteBytes(PINNACLE_ERA_ADDR, buffer, 2);
     rapWrite(PINNACLE_ERA_CONTROL, 0x0A); // indicate writing sequential bytes
     for (uint8_t i = 0; i < repeat; i++) {
-        do {
-            rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
-        } while (buffer[0]);
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+        if (!_rev2025) {
+#endif
+            do {
+                rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
+            } while (buffer[0]);
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+        }
+        else {
+            while (!digitalRead(_dataReady))
+            {
+            }
+        }
+#endif
         clearStatusFlags(); // clear Command Complete flag in Status register
     }
     if (prevFeedState) {
@@ -491,16 +519,33 @@ void PinnacleTouch::eraWriteBytes(uint16_t registerAddress, uint8_t registerValu
 
 void PinnacleTouch::eraRead(uint16_t registerAddress, uint8_t* data)
 {
+    PINNACLE_USE_ARDUINO_API
     bool prevFeedState = isFeedEnabled();
     if (prevFeedState) {
         feedEnabled(false); // accessing raw memory, so do this
     }
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    if (_rev2025) {
+        clearStatusFlags();
+    }
+#endif
     uint8_t buffer[2] = {(uint8_t)(registerAddress >> 8), (uint8_t)(registerAddress & 0xFF)};
     rapWriteBytes(PINNACLE_ERA_ADDR, buffer, 2);
     rapWrite(PINNACLE_ERA_CONTROL, 1); // indicate reading only 1 byte
-    do {
-        rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
-    } while (buffer[0]);
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    if (!_rev2025) {
+#endif
+        do {
+            rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
+        } while (buffer[0]);
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    }
+    else {
+        while (!digitalRead(_dataReady))
+        {
+        }
+    }
+#endif
     rapRead(PINNACLE_ERA_VALUE, data); // get data
     clearStatusFlags();                // clear Command Complete flag in Status register
     if (prevFeedState) {
@@ -510,17 +555,34 @@ void PinnacleTouch::eraRead(uint16_t registerAddress, uint8_t* data)
 
 void PinnacleTouch::eraReadBytes(uint16_t registerAddress, uint8_t* data, uint8_t registerCount)
 {
+    PINNACLE_USE_ARDUINO_API
     bool prevFeedState = isFeedEnabled();
     if (prevFeedState) {
         feedEnabled(false); // accessing raw memory, so do this
     }
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    if (_rev2025) {
+        clearStatusFlags();
+    }
+#endif
     uint8_t buffer[2] = {(uint8_t)(registerAddress >> 8), (uint8_t)(registerAddress & 0xFF)};
     rapWriteBytes(PINNACLE_ERA_ADDR, buffer, 2);
     for (uint8_t i = 0; i < registerCount; ++i) {
         rapWrite(PINNACLE_ERA_CONTROL, 5); // indicate reading sequential bytes
-        do {
-            rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
-        } while (buffer[0]);
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+        if (!_rev2025) {
+#endif
+            do {
+                rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
+            } while (buffer[0]);
+#ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+        }
+        else {
+            while (!digitalRead(_dataReady))
+            {
+            }
+        }
+#endif
         rapRead(PINNACLE_ERA_VALUE, data + i); // get value
         clearStatusFlags();                    // clear Command Complete flag in Status register
     }
@@ -528,13 +590,6 @@ void PinnacleTouch::eraReadBytes(uint16_t registerAddress, uint8_t* data, uint8_
         feedEnabled(prevFeedState); // resume previous feed state
     }
 }
-
-#if PINNACLE_DEV_HW_DEBUG
-void PinnacleTouch::readRegisters(uint8_t reg, uint8_t* data, uint8_t len)
-{
-    rapReadBytes(reg, data, len);
-}
-#endif
 
 PinnacleTouchSPI::PinnacleTouchSPI(pinnacle_gpio_t dataReadyPin, pinnacle_gpio_t slaveSelectPin, uint32_t spiSpeed)
     : PinnacleTouch(dataReadyPin), _slaveSelect(slaveSelectPin), _spiSpeed(spiSpeed)

--- a/src/CirquePinnacle.h
+++ b/src/CirquePinnacle.h
@@ -545,7 +545,7 @@ public:
      *     or stylus with a 5.25mm diameter tip.
      *
      *     .. warning:: This method is |rev2025| Specifying the values ``200`` or ``300``
-     *         |rev2025-no-effect| and will be clamped to ``100``.
+     *         and will automatically be clamped to ``100``.
      */
     void setSampleRate(uint16_t value);
     /**
@@ -815,11 +815,6 @@ public:
      */
     int16_t getMeasureAdc();
 #endif // PINNACLE_ANYMEAS_SUPPORT == true
-
-#if PINNACLE_DEV_HW_DEBUG
-    // A handy function to get a register dump from the sensor.
-    void readRegisters(uint8_t reg, uint8_t* data, uint8_t len);
-#endif
 
 private:
     void eraWrite(uint16_t, uint8_t);

--- a/src/CirquePinnacle_common.h
+++ b/src/CirquePinnacle_common.h
@@ -34,11 +34,6 @@
     #define PINNACLE_ANYMEAS_SUPPORT true
 #endif // !defined(PINNACLE_ANYMEAS_SUPPORT)
 
-#ifndef PINNACLE_DEV_HW_DEBUG
-    // a switch to expose a convenient function for HW debugging.
-    #define PINNACLE_DEV_HW_DEBUG false
-#endif
-
 #if defined(ARDUINO)
     #include <Arduino.h>
     #include <SPI.h>

--- a/src/utility/rp2/CMakeLists.txt
+++ b/src/utility/rp2/CMakeLists.txt
@@ -8,7 +8,13 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 
 option(PINNACLE_ANYMEAS_SUPPORT "Enable anymeas mode support" ON)
-option(PINNACLE_DEV_HW_DEBUG "Expose register read function" OFF)
+option(PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
+    "Allow experimental ERA functionality on trackpads with newer firmware.
+    To use this feature, C++ inheritance shall be used
+    because the ERA functions are private.
+    Does not apply to the Python binding."
+    OFF
+)
 
 # Define the CirquePinnacle core library
 add_library(CirquePinnacle INTERFACE)
@@ -18,9 +24,9 @@ if(NOT PINNACLE_ANYMEAS_SUPPORT)
     target_compile_definitions(CirquePinnacle INTERFACE PINNACLE_ANYMEAS_SUPPORT=0)
 endif()
 
-if(PINNACLE_DEV_HW_DEBUG)
-    message(STATUS "Exposing debug function: readRegisters(regOffset, buf, count)")
-    target_compile_definitions(CirquePinnacle INTERFACE PINNACLE_DEV_HW_DEBUG=1)
+if (PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE)
+    message(STATUS "Allowing experimental ERA functionality on newer trackpads")
+    target_compile_definitions(${LibTargetName} PUBLIC PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE=1)
 endif()
 
 # generate the lib-specific includes.h for the Pico SDK


### PR DESCRIPTION
I accidentally merged #33 before adding these changes.

Reduces compile size by limiting ERA functionality in `PinnacleTouch::begin()`.

Allows conditionally compiling experimental ERA support for newer firmware. This can be used in C++ if inheriting from a `PinnacleTouch*` class because the ERA functions are private. It does not apply to python bindings (use `circuitpython_cirque_pinnacle` package instead).
#### Using CMake (Linux and PicoSDK), enable with
```text
cmake ../src -DPINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE=ON
```
#### Using Arduino IDE, you must add the following to `CirquePinnacle_common.h`:
```c++
#define PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
```
#### Using PlatformIO, enable with
```ini
# in platformio.ini
build_flags = 
  -DPINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE=ON
``` 
