### PR TITLE
use `/dev/gpiochip0` by default on Linux

### DIFF
--- a/examples/linux/absolute_mode.cpp
+++ b/examples/linux/absolute_mode.cpp
@@ -44,9 +44,9 @@ bool setup()
     std::cout << "-- Using I2C interface." << std::endl;
 #endif
     std::cout << "\nShow trigonometric calculations? [y/N] ('N' means show raw data) ";
-    char input;
-    std::cin >> input;
-    onlyShowTrigVals = input == 'y' || input == 'Y';
+    char input[4] = {0};
+    std::cin.getline(input, 3);
+    onlyShowTrigVals = input[0] == 'y' || input[0] == 'Y';
     std::cout << "showing ";
     if (onlyShowTrigVals)
         std::cout << "trigonometric calculations." << std::endl;

--- a/src/CirquePinnacle.cpp
+++ b/src/CirquePinnacle.cpp
@@ -45,6 +45,9 @@ bool PinnacleTouch::begin()
         while (available()) {
             clearStatusFlags(); // ignore/discard all pending measurements waiting to be read()
         }
+        if (!_rev2025) {
+            setAdcGain(0); // most sensitive attenuation
+        }
         if (calibrate()) { // enables all compensations, runs calibration, & clearStatusFlags()
             feedEnabled(true);
             return true;

--- a/src/CirquePinnacle.cpp
+++ b/src/CirquePinnacle.cpp
@@ -459,7 +459,7 @@ void PinnacleTouch::eraWrite(uint16_t registerAddress, uint8_t registerValue)
     if (!_rev2025) {
 #endif
         do {
-            rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
+            rapRead(PINNACLE_ERA_CONTROL, buffer); // read until register value == 0
         } while (buffer[0]);
 #ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
     }
@@ -497,7 +497,7 @@ void PinnacleTouch::eraWriteBytes(uint16_t registerAddress, uint8_t registerValu
         if (!_rev2025) {
 #endif
             do {
-                rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
+                rapRead(PINNACLE_ERA_CONTROL, buffer); // read until register value == 0
             } while (buffer[0]);
 #ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
         }
@@ -533,7 +533,7 @@ void PinnacleTouch::eraRead(uint16_t registerAddress, uint8_t* data)
     if (!_rev2025) {
 #endif
         do {
-            rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
+            rapRead(PINNACLE_ERA_CONTROL, buffer); // read until register value == 0
         } while (buffer[0]);
 #ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
     }
@@ -570,7 +570,7 @@ void PinnacleTouch::eraReadBytes(uint16_t registerAddress, uint8_t* data, uint8_
         if (!_rev2025) {
 #endif
             do {
-                rapRead(PINNACLE_ERA_CONTROL, buffer); // read until registerAddress == 0
+                rapRead(PINNACLE_ERA_CONTROL, buffer); // read until register value == 0
             } while (buffer[0]);
 #ifdef PINNACLE_EXPERIMENTAL_ERA_2025_FIRMWARE
         }

--- a/src/utility/linux_kernel/gpio.h
+++ b/src/utility/linux_kernel/gpio.h
@@ -32,10 +32,9 @@ typedef unsigned int pinnacle_gpio_t;
 
     #ifndef PINNACLE_LINUX_GPIO_CHIP
         /**
-         * The default GPIO chip to use.  Defaults to `/dev/gpiochip4` (for RPi5).
-         * Falls back to `/dev/gpiochip0` if this value is somehow incorrect.
+         * The default GPIO chip to use.  Defaults to `/dev/gpiochip0`.
          */
-        #define PINNACLE_LINUX_GPIO_CHIP "/dev/gpiochip4"
+        #define PINNACLE_LINUX_GPIO_CHIP "/dev/gpiochip0"
     #endif
 namespace cirque_pinnacle_arduino_wrappers {
 
@@ -53,9 +52,7 @@ namespace cirque_pinnacle_arduino_wrappers {
     /// This struct's destructor should close any cached GPIO pin requests' file descriptors.
     struct GPIOChipCache
     {
-        const char* chip = PINNACLE_LINUX_GPIO_CHIP;
-        int fd = -1;
-        bool chipInitialized = false;
+        static int fd;
 
         /// Open the File Descriptor for the GPIO chip
         void openDevice();


### PR DESCRIPTION
Change default gpiochip to `/dev/gpiochip0`.

Some time in the last year, an update to the RPi OS now uses gpiochip0 for all models and symlinks `/dev/gpiochip4` to target `/dev/gpiochip0`.

This should also resolve problems in some RPi clones (eg rockchip 3588 boards) where both gpiochip0 and gpiochip4 are separate existing entities.